### PR TITLE
Show "unsupported" alert in Safari

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@capacitor/core": "2.4.5",
     "@ionic/vue": "^5.4.0",
     "@ionic/vue-router": "^5.4.0",
+    "bowser": "^2.11.0",
     "core-js": "^3.6.5",
     "streamsaver": "^2.0.5",
     "vue": "^3.0.0-0",

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,4 +1,8 @@
-import {Action, ActionContext, createStore, Module, Store} from 'vuex'
+import {ActionContext, createStore, Store} from 'vuex'
+import {alertController, modalController} from "@ionic/vue";
+import {AlertOptions} from "@ionic/core";
+import Bowser from "bowser";
+
 import {ClientConfig, TransferOptions, TransferProgress} from "@/go/wormhole/types";
 import {DEFAULT_PROD_CLIENT_CONFIG} from "@/go/wormhole/client";
 import {
@@ -14,8 +18,6 @@ import {
     UPDATE_PROGRESS_ETA
 } from "@/store/actions";
 import ClientWorker from "@/go/wormhole/client_worker";
-import {alertController} from "@ionic/vue";
-import {AlertOptions} from "@ionic/core";
 import {ErrRelay, ErrMailbox, ErrInterrupt, ErrBadCode, MatchableErrors} from "@/errors";
 import {durationToClosesUnit, sizeToClosestUnit} from "@/util";
 
@@ -39,7 +41,23 @@ if (process.env['NODE_ENV'] === 'production') {
     host = 'https://wormhole.bryanchriswhite.com';
 }
 
-let client = new ClientWorker(defaultConfig);
+let client: ClientWorker;
+
+const safariNotSupportedError = Error("Safari is currently not supported but will be in future releases.")
+const browser = Bowser.getParser(self.navigator.userAgent)
+const browserIsProbablySafari = browser.satisfies({
+    safari: '>0'
+});
+if (browserIsProbablySafari) {
+    const modal = alertController.create({
+        header: 'Safari not supported :\'(',
+        message: safariNotSupportedError.message,
+        backdropDismiss: false,
+    });
+    modal.then(m => m.present());
+} else {
+    client = new ClientWorker(defaultConfig);
+}
 
 /* --- ACTIONS --- */
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -43,7 +43,7 @@ if (process.env['NODE_ENV'] === 'production') {
 
 let client: ClientWorker;
 
-const safariNotSupportedError = Error("Safari is currently not supported but will be in future releases.")
+const safariNotSupportedError = Error("We plan to support Safari in future releases. Please try with a different browser.")
 const browser = Bowser.getParser(self.navigator.userAgent)
 const browserIsProbablySafari = browser.satisfies({
     safari: '>0'

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -18,6 +18,12 @@ import {
     WASM_READY
 } from "@/store/actions";
 import {RpcProvider} from "worker-rpc";
+import Bowser from "bowser";
+
+const browser = Bowser.getParser(self.navigator.userAgent)
+const browserIsProbablySafari = browser.satisfies({
+    safari: '>0'
+});
 
 const wasmPromise = fetch("/assets/wormhole.wasm");
 let rpc: RpcProvider | undefined = undefined;
@@ -123,53 +129,55 @@ async function handleReceiveFileData({id}: RPCMessage): Promise<void> {
     }
 }
 
-onmessage = async function (event) {
-    if (!isRPCMessage(event.data)) {
-        throw new Error(`unexpected event: ${JSON.stringify(event, null, '  ')}`);
+if (!browserIsProbablySafari) {
+    onmessage = async function (event) {
+        if (!isRPCMessage(event.data)) {
+            throw new Error(`unexpected event: ${JSON.stringify(event, null, '  ')}`);
+        }
+
+        // NB: unregister worker message handler.
+        //  (use message channel port instead)
+        onmessage = () => {
+            // NB: noop
+        };
+
+        const go = new Go();
+        let wasm: { instance: WebAssembly.Instance };
+        if (typeof (WebAssembly.instantiateStreaming) === 'undefined') {
+            const wasmData = await (await wasmPromise).arrayBuffer();
+            wasm = await WebAssembly.instantiate(wasmData, go.importObject);
+        } else {
+            wasm = await WebAssembly.instantiateStreaming(wasmPromise, go.importObject)
+        }
+        go.run(wasm.instance);
+
+        client = new Client(event.data.config);
+        port = event.ports[0]
+        port.postMessage({
+            action: WASM_READY,
+            goClient: client.goClient,
+        });
+
+        rpc = new RpcProvider((message: any, transfer: any[] | undefined) => {
+            typeof (transfer) === 'undefined' ?
+                port.postMessage(message) :
+                port.postMessage(message, transfer);
+        });
+
+        rpc.registerRpcHandler<RPCMessage, string>(SEND_TEXT, async ({text}) => {
+            return client.sendText(text);
+        })
+        rpc.registerRpcHandler<RPCMessage, string>(RECV_TEXT, async ({code}) => {
+            return client.recvText(code);
+        })
+        // TODO: be more specific with types!
+        rpc.registerRpcHandler<RPCMessage, Record<string, any>>(SEND_FILE, handleSendFile);
+        rpc.registerRpcHandler<RPCMessage, void>(SEND_FILE_CANCEL, handleSendFileCancel);
+        // TODO: be more specific with types!
+        rpc.registerRpcHandler<RPCMessage, Record<string, any>>(RECV_FILE, handleReceiveFile);
+        rpc.registerRpcHandler<RPCMessage, void>(RECV_FILE_DATA, handleReceiveFileData);
+        rpc.registerRpcHandler<RPCMessage, void>(FREE, () => client.free());
+
+        port.onmessage = (event: MessageEvent) => rpc!.dispatch(event.data);
     }
-
-    // NB: unregister worker message handler.
-    //  (use message channel port instead)
-    onmessage = () => {
-        // NB: noop
-    };
-
-    const go = new Go();
-    let wasm: { instance: WebAssembly.Instance };
-    if (typeof (WebAssembly.instantiateStreaming) === 'undefined') {
-        const wasmData = await (await wasmPromise).arrayBuffer();
-        wasm = await WebAssembly.instantiate(wasmData, go.importObject);
-    } else {
-        wasm = await WebAssembly.instantiateStreaming(wasmPromise, go.importObject)
-    }
-    go.run(wasm.instance);
-
-    client = new Client(event.data.config);
-    port = event.ports[0]
-    port.postMessage({
-        action: WASM_READY,
-        goClient: client.goClient,
-    });
-
-    rpc = new RpcProvider((message: any, transfer: any[] | undefined) => {
-        typeof (transfer) === 'undefined' ?
-            port.postMessage(message) :
-            port.postMessage(message, transfer);
-    });
-
-    rpc.registerRpcHandler<RPCMessage, string>(SEND_TEXT, async ({text}) => {
-        return client.sendText(text);
-    })
-    rpc.registerRpcHandler<RPCMessage, string>(RECV_TEXT, async ({code}) => {
-        return client.recvText(code);
-    })
-    // TODO: be more specific with types!
-    rpc.registerRpcHandler<RPCMessage, Record<string, any>>(SEND_FILE, handleSendFile);
-    rpc.registerRpcHandler<RPCMessage, void>(SEND_FILE_CANCEL, handleSendFileCancel);
-    // TODO: be more specific with types!
-    rpc.registerRpcHandler<RPCMessage, Record<string, any>>(RECV_FILE, handleReceiveFile);
-    rpc.registerRpcHandler<RPCMessage, void>(RECV_FILE_DATA, handleReceiveFileData);
-    rpc.registerRpcHandler<RPCMessage, void>(FREE, () => client.free());
-
-    port.onmessage = (event: MessageEvent) => rpc!.dispatch(event.data);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2783,6 +2783,11 @@ boolbase@^1.0.0, boolbase@~1.0.0:
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
 
+bowser@^2.11.0:
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/bowser/-/bowser-2.11.0.tgz#5ca3c35757a7aa5771500c70a73a9f91ef420a8f"
+  integrity sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"


### PR DESCRIPTION
This implements #36.

- [x] Add `UnsupportedModal` component
- [x] Use `UnsupportedModal` if we detect that we're in safari
- [x] Fix styling to match existing alert modal
- [x] Update copy

---

## Code Review Checklist (to be filled out by reviewer)

- [x] Description accurately reflects what changes are being made.
- [x] Description explains why the changes are being made (or references an issue containing one).
- [x] The PR appropriately sized.
~~- [ ] New code has enough tests.~~
~~- [ ] New code has enough documentation to answer "how do I use it?" and "what does it do?".~~
~~- [ ] Existing documentation is up-to-date, if impacted.~~
