### PR TITLE
Make safari modal dismissable and re-alert

### DIFF
--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -48,9 +48,9 @@ let client: ClientWorker;
 
 const safariNotSupportedError = Error("We plan to support Safari in future releases. Please try with a different browser.")
 const browser = Bowser.getParser(self.navigator.userAgent)
-if (!alertIfInSafari()) {
-    client = new ClientWorker(defaultConfig);
-}
+const noop = () => {
+    console.error(safariNotSupportedError);
+};
 
 function alertIfInSafari(): boolean {
     const browserIsProbablySafari = browser.satisfies({
@@ -65,7 +65,11 @@ function alertIfInSafari(): boolean {
         });
         modal.then(m => m.present());
     }
-    return browserIsProbablySafari;
+    return browserIsProbablySafari || false;
+}
+
+if (!alertIfInSafari()) {
+    client = new ClientWorker(defaultConfig);
 }
 
 /* --- ACTIONS --- */
@@ -99,7 +103,7 @@ async function sendFileAction(this: Store<any>, {
     dispatch
 }: ActionContext<any, any>, {file, opts}: SendFilePayload): Promise<TransferProgress> {
     if (alertIfInSafari()) {
-        return {code: '', done: new Promise(() => {})};
+        return {code: '', done: new Promise(noop)};
     }
 
     // NB: reset code
@@ -160,7 +164,7 @@ async function saveFileAction(this: Store<any>, {
     state, commit, dispatch
 }: ActionContext<any, any>, code: string): Promise<TransferProgress> {
     if (alertIfInSafari()) {
-        return {code: '', done: new Promise(() => {})};
+        return {code: '', done: new Promise(noop)};
     }
 
     const opts = {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -48,18 +48,24 @@ let client: ClientWorker;
 
 const safariNotSupportedError = Error("We plan to support Safari in future releases. Please try with a different browser.")
 const browser = Bowser.getParser(self.navigator.userAgent)
-const browserIsProbablySafari = browser.satisfies({
-    safari: '>0'
-});
-if (browserIsProbablySafari) {
-    const modal = alertController.create({
-        header: 'Safari not supported :\'(',
-        message: safariNotSupportedError.message,
-        backdropDismiss: false,
-    });
-    modal.then(m => m.present());
-} else {
+if (!alertIfInSafari()) {
     client = new ClientWorker(defaultConfig);
+}
+
+function alertIfInSafari(): boolean {
+    const browserIsProbablySafari = browser.satisfies({
+        safari: '>0'
+    });
+    if (browserIsProbablySafari) {
+        const modal = alertController.create({
+            header: 'Safari not supported :\'(',
+            message: safariNotSupportedError.message,
+            backdropDismiss: true,
+            buttons: ['OK'],
+        });
+        modal.then(m => m.present());
+    }
+    return browserIsProbablySafari;
 }
 
 /* --- ACTIONS --- */
@@ -69,6 +75,10 @@ async function newClientAction(this: Store<any>, {
     state,
     commit
 }: ActionContext<any, any>, config?: ClientConfig): Promise<void> {
+    if (alertIfInSafari()) {
+        return;
+    }
+
     // TODO: something better.
     let _config = config;
     if (typeof (config) === 'undefined') {
@@ -88,6 +98,10 @@ async function sendFileAction(this: Store<any>, {
     commit,
     dispatch
 }: ActionContext<any, any>, {file, opts}: SendFilePayload): Promise<TransferProgress> {
+    if (alertIfInSafari()) {
+        return {code: '', done: new Promise(() => {})};
+    }
+
     // NB: reset code
     commit(SET_CODE, '');
 
@@ -145,6 +159,10 @@ Please select a smaller file.`,
 async function saveFileAction(this: Store<any>, {
     state, commit, dispatch
 }: ActionContext<any, any>, code: string): Promise<TransferProgress> {
+    if (alertIfInSafari()) {
+        return {code: '', done: new Promise(() => {})};
+    }
+
     const opts = {
         progressFunc: (sentBytes: number, totalBytes: number) => {
             // TODO: refactor


### PR DESCRIPTION
Makes "safari unsupported" modal dismissable via "OK" button or clicking on the backdrop.
The alert re-appears if a user selects a file or enters a code.

---

## Code Review Checklist (to be filled out by reviewer)

- [ ] Description accurately reflects what changes are being made.
- [ ] Description explains why the changes are being made (or references an issue containing one).
- [ ] The PR appropriately sized.
- [ ] New code has enough tests.
- [ ] New code has enough documentation to answer "how do I use it?" and "what does it do?".
- [ ] Existing documentation is up-to-date, if impacted.
