### PR TITLE
Update relay Dockerfile to add CLI args

### DIFF
--- a/docker/relay/Dockerfile
+++ b/docker/relay/Dockerfile
@@ -7,4 +7,4 @@ RUN pip install pipenv
 WORKDIR /app
 RUN pipenv install
 
-CMD bash -c "pipenv install --dev -e . && pipenv run twist transitrelay"
+CMD bash -c "pipenv install --dev -e . && pipenv run twist transitrelay --port=tcp:4001 --websocket=tcp:4002"


### PR DESCRIPTION
My local development relay stopped working after the submodule update switching to the magic-wormhole org fork.
It looks like it was missing some CLI arguments based on what @vu3rdd put in the [github actions]() script for the relay there (thanks again @vu3rdd!).

---

## Code Review Checklist (to be filled out by reviewer)

- [ ] Description accurately reflects what changes are being made.
- [ ] Description explains why the changes are being made (or references an issue containing one).
- [ ] The PR appropriately sized.
- [ ] New code has enough tests.
- [ ] New code has enough documentation to answer "how do I use it?" and "what does it do?".
- [ ] Existing documentation is up-to-date, if impacted.
