### PR TITLE
SENDER_TIMEOUT should be larger than 3 seconds

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -1,5 +1,5 @@
 // NB: wormhole-william relay timeout is 5s.
-export const SENDER_TIMEOUT = 3000;
+export const SENDER_TIMEOUT = 10000;
 
 export const CODE_REGEX = /^\d+-\w+-\w+$/;
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,5 +1,4 @@
-// NB: wormhole-william relay timeout is 5s.
-export const SENDER_TIMEOUT = 10000;
+export const SENDER_TIMEOUT = 60 * 10 * 1000; // 10 minutes in milliseconds
 
 export const CODE_REGEX = /^\d+-\w+-\w+$/;
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,4 @@
-export const SENDER_TIMEOUT = 60 * 10 * 1000; // 10 minutes in milliseconds
+export const SENDER_TIMEOUT = 10 * 60 * 1000; // 10 minutes in milliseconds
 
 export const CODE_REGEX = /^\d+-\w+-\w+$/;
 


### PR DESCRIPTION
SENDER_TIMEOUT kicks in when the recipient URL is loaded. Within the
timeout, the recipient is supposed to talk to the mailbox server and
get the offer message with filename and file size. If this doesn't
happen, the BadCodeError is displayed. However, in some networks, it
may take more than 3 seconds to load. Increasing it here to 10s.

Closes #79 
---

## Code Review Checklist (to be filled out by reviewer)

- [x] Description accurately reflects what changes are being made.
- [x] Description explains why the changes are being made (or references an issue containing one).
- [x] The PR appropriately sized.
- [x] New code has enough tests.
- [x] New code has enough documentation to answer "how do I use it?" and "what does it do?".
- [x] Existing documentation is up-to-date, if impacted.
