### PR TITLE
fix crash due to missing variable

### DIFF
--- a/src/go/wormhole/client_worker.ts
+++ b/src/go/wormhole/client_worker.ts
@@ -124,7 +124,7 @@ export default class ClientWorker implements ClientInterface {
 
     private _handleSendFileResultOK({id}: RPCMessage): void {
         console.log('client_worker.ts:127 | _handleSendFileResultOK');
-        const {result: {resolve}} = this.pending[id];
+        const {done: {resolve}} = this.pending[id];
         resolve();
     }
 


### PR DESCRIPTION
A pattern matching assignment like:

> const {result: {resolve}} = this.pending[id];

results in the desugaring of the pattern to:

> resolve = this.pending[id].result

This is where the error shown to the user starts to make sense. 

However, inspecting the object `this.pending[id]` revealed that it
only has `size` key and `done` key. So, replace "result" with "done".

Closes #88 

---

## Code Review Checklist (to be filled out by reviewer)

- [ ] Description accurately reflects what changes are being made.
- [ ] Description explains why the changes are being made (or references an issue containing one).
- [ ] The PR appropriately sized.
- [ ] New code has enough tests.
- [ ] New code has enough documentation to answer "how do I use it?" and "what does it do?".
- [ ] Existing documentation is up-to-date, if impacted.
