### PR TITLE
Fix build script command

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -24,7 +24,7 @@ try {
     exit(3);
 }
 
-const command2 = `NODE_ENV=${stage} vue-cli-service build`
+const command2 = `NODE_ENV=${stage} ./node_modules/.bin/vue-cli-service build`;
 try {
     execSync(command2);
 } catch (error) {


### PR DESCRIPTION
Fixes the executable `vue-cli-service` not found error when trying to run the build script
OP#552

---

## Code Review Checklist (to be filled out by reviewer)

- [ ] Description accurately reflects what changes are being made.
- [ ] Description explains why the changes are being made (or references an issue containing one).
- [ ] The PR appropriately sized.
- [ ] New code has enough tests.
- [ ] New code has enough documentation to answer "how do I use it?" and "what does it do?".
- [ ] Existing documentation is up-to-date, if impacted.
