### PR TITLE
Use the PR head for the build and test workflow.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+        with:
+          # Checkout head of the branch of the PR, or the exact revision
+          # specified for non-PR builds.
+          ref: "${{ github.event.pull_request.head.sha || github.sha }}"
 
       - name: checkout and update submodules
         run: git submodule update --init --recursive


### PR DESCRIPTION
For non-PR builds, use exactly the triggering revision.

This prevents jobs from running with an unpredictable version of the source
that varies depending on whether changes are made to the merge base or not.

This is like LeastAuthority/wormhole-william#66.

---

## Code Review Checklist (to be filled out by reviewer)

- [ ] Description accurately reflects what changes are being made.
- [ ] Description explains why the changes are being made (or references an issue containing one).
- [ ] The PR appropriately sized.
- [ ] New code has enough tests.
- [ ] New code has enough documentation to answer "how do I use it?" and "what does it do?".
- [ ] Existing documentation is up-to-date, if impacted.
